### PR TITLE
chore: test_files and require_paths shouldn't be included in the gemspec

### DIFF
--- a/wallaby-core.gemspec
+++ b/wallaby-core.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
     'LICENSE',
     'README.md'
   ]
-  spec.test_files = Dir['spec/**/*']
-  spec.require_paths = ['lib']
 
   spec.add_dependency 'parslet'
   spec.add_dependency 'rails', '>= 4.2.0'


### PR DESCRIPTION
### Summary

Take out `test_files` and `require_paths` as they are not needed