### PR TITLE
fix: same options being used for multiple index_link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,23 @@
+# folders
 /.bundle/
-/.yardoc
+/.yardoc/
 /_yardoc/
 /coverage/
 /doc/
 /pkg/
 /spec/reports/
-/tmp/
+doc/
+tmp/
+log/
 
-# rspec failure tracking
+coverage/
+deep_cover/
+
+# files
+cc-test-reporter
 .rspec_status
+.byebug_history
 Gemfile.lock
 *.gem
+*.sqlite3
+*.sqlite3-journal

--- a/lib/services/wallaby/link_options_normalizer.rb
+++ b/lib/services/wallaby/link_options_normalizer.rb
@@ -9,6 +9,7 @@ module Wallaby
     # @param defaults [Hash]
     # @return [Array<Hash, Proc>] html_options and the block
     def self.normalize(html_options, block, defaults)
+      html_options = Utils.clone html_options
       block ||= defaults[:block]
       html_options[:title] ||= defaults[:block].call
       # allow empty class to be set

--- a/lib/services/wallaby/sorting/next_builder.rb
+++ b/lib/services/wallaby/sorting/next_builder.rb
@@ -22,7 +22,7 @@ module Wallaby
       # @return [ActionController::Parameters]
       #   updated parameters with new sort order for given field
       def next_params(field_name)
-        params = @params.dup
+        params = Utils.clone @params
         params[:sort] = complete_sorting_str_with field_name
         params
       end

--- a/lib/support/action_dispatch/routing/mapper.rb
+++ b/lib/support/action_dispatch/routing/mapper.rb
@@ -18,7 +18,7 @@ module ActionDispatch
       # @see https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources
       #   ActionDispatch::Routing::Mapper::Resources#resources
       def wresources(*resource_names, &block)
-        options = resource_names.extract_options!.dup
+        options = Wallaby::Utils.clone resource_names.extract_options!
         resource_names.each do |resource_name|
           new_options = wallaby_resources_options_for resource_name, options
           resources resource_name, new_options, &block
@@ -39,7 +39,7 @@ module ActionDispatch
       # @see https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resource
       #   ActionDispatch::Routing::Mapper::Resources#resource
       def wresource(*resource_names, &block)
-        options = resource_names.extract_options!.dup
+        options = Wallaby::Utils.clone resource_names.extract_options!
         resource_names.each do |resource_name|
           new_options = wallaby_resource_options_for resource_name, options
           resource resource_name, new_options, &block

--- a/lib/wallaby/core/version.rb
+++ b/lib/wallaby/core/version.rb
@@ -2,6 +2,6 @@
 
 module Wallaby
   module Core
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
### Summary

This is to fix an issue caused by modifying the same options object in `Wallaby:: LinkOptionsNormalizer`.
The fix is to clone the html options object.