### PR TITLE
fix: make cell utils to work with path that starts with /app/vendor

### DIFF
--- a/lib/utils/wallaby/cell_utils.rb
+++ b/lib/utils/wallaby/cell_utils.rb
@@ -10,7 +10,7 @@ module Wallaby
       # @param locals [Hash]
       # @return [String] output
       def render(context, file_name, locals = {}, &block)
-        snake_class = file_name[%r{(?<=app/).+(?=\.rb)}].split(SLASH, 2).last
+        snake_class = file_name[%r{(?<=app/views).+(?=\.rb)}]
         cell_class = snake_class.camelize.constantize
         Rails.logger.info "  Rendered [cell] #{file_name}"
         cell_class.new(context, locals).render_complete(&block)

--- a/lib/utils/wallaby/cell_utils.rb
+++ b/lib/utils/wallaby/cell_utils.rb
@@ -10,7 +10,7 @@ module Wallaby
       # @param locals [Hash]
       # @return [String] output
       def render(context, file_name, locals = {}, &block)
-        snake_class = file_name[%r{(?<=app/views).+(?=\.rb)}]
+        snake_class = file_name[%r{(?<=app/views/).+(?=\.rb)}]
         cell_class = snake_class.camelize.constantize
         Rails.logger.info "  Rendered [cell] #{file_name}"
         cell_class.new(context, locals).render_complete(&block)

--- a/lib/wallaby/core/version.rb
+++ b/lib/wallaby/core/version.rb
@@ -2,6 +2,6 @@
 
 module Wallaby
   module Core
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
### Summary

To fix an issue caused by cell file path that starts with /app/vendor on heroku, for example:

```
/app/vendor/bundle/ruby/2.6.0/gems/wallaby-6.0.2/app/views/wallaby/resources/index/belongs_to_html.rb
```