### PR TITLE
fix: Wallaby::PreloadUtils#eager_load_paths for Pathname objects

### DIFF
--- a/lib/utils/wallaby/preload_utils.rb
+++ b/lib/utils/wallaby/preload_utils.rb
@@ -22,7 +22,7 @@ module Wallaby
       #   at highest precedence
       def eager_load_paths
         Rails.configuration.eager_load_paths.sort_by do |path|
-          - path.index(%r{/models$}).to_i
+          - path.to_s.index(%r{/models$}).to_i
         end
       end
 


### PR DESCRIPTION
### Summary

Rails.configuration.eager_load_paths can include Pathname objects that doesn't have #index.


