### PR TITLE
chore: only define Ability when CanCan exists

### DIFF
--- a/app/security/ability.rb
+++ b/app/security/ability.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# @!visibility private
-# Defualt ability for wallaby
-# If main app has defined `ability.rb`, this file will not be loaded/used.
-class Ability
-  include ::CanCan::Ability
+if defined?(::CanCan)
+  # @!visibility private
+  # Defualt ability for wallaby
+  # If main app has defined `ability.rb`, this file will not be loaded/used.
+  class Ability
+    include ::CanCan::Ability
 
-  # @param _user [Object]
-  def initialize(_user)
-    can :manage, :all
+    # @param _user [Object]
+    def initialize(_user)
+      can :manage, :all
+    end
   end
 end


### PR DESCRIPTION
### Summary

see https://github.com/wallaby-rails/wallaby/issues/165

When eager loading is set and CanCan is not used, it will raise error