### PR TITLE
chore: deprecate features config and rename to max_text_length

### DIFF
--- a/lib/concerns/wallaby/configurable.rb
+++ b/lib/concerns/wallaby/configurable.rb
@@ -349,24 +349,24 @@ module Wallaby
 
     # Metadata configurables
     module ClassMethods
-      # @!attribute [r] max_length
+      # @!attribute [r] max_text_length
       # To configure max number of characters to truncate for each text field on index page.
       # @example To update the email method in `Admin::ApplicationController`
       #   class Admin::ApplicationController < Wallaby::ResourcesController
-      #     self.max_length = 50
+      #     self.max_text_length = 50
       #   end
       # @return [Integer] max number of characters to truncate, default to 20
       # @see Wallaby::DEFAULT_MAX
       # @since 0.2.3
-      def max_length
-        @max_length || superclass.try(:max_length) || DEFAULT_MAX
+      def max_text_length
+        @max_text_length || superclass.try(:max_text_length) || DEFAULT_MAX
       end
 
-      # @!attribute [w] max_length
-      def max_length=(max_length)
-        case max_length
+      # @!attribute [w] max_text_length
+      def max_text_length=(max_text_length)
+        case max_text_length
         when Integer, nil
-          @max_length = max_length
+          @max_text_length = max_text_length
         else
           raise ArgumentError, 'Please provide a Integer value or nil'
         end

--- a/lib/helpers/wallaby/application_helper.rb
+++ b/lib/helpers/wallaby/application_helper.rb
@@ -41,26 +41,6 @@ module Wallaby
       end || super(options)
     end
 
-    # Override origin method to add turbolinks tracking when it's enabled
-    # @param sources [Array<String>]
-    # @return [String] stylesheet link tags HTML
-    def stylesheet_link_tag(*sources)
-      default_options =
-        features.turbolinks_enabled ? { 'data-turbolinks-track' => true } : {}
-      options = default_options.merge!(sources.extract_options!.stringify_keys)
-      super(*sources, options)
-    end
-
-    # Override origin method to add turbolinks tracking when it's enabled
-    # @param sources [Array<String>]
-    # @return [String] javascript script tags HTML
-    def javascript_include_tag(*sources)
-      default_options =
-        features.turbolinks_enabled ? { 'data-turbolinks-track' => true, 'data-turbolinks-eval' => false } : {}
-      options = default_options.merge!(sources.extract_options!.stringify_keys)
-      super(*sources, options)
-    end
-
     # @param key
     # @param options [Hash]
     def wt(key, options = {})

--- a/lib/helpers/wallaby/configuration_helper.rb
+++ b/lib/helpers/wallaby/configuration_helper.rb
@@ -4,7 +4,7 @@ module Wallaby
   # Configuration helper module. Provide shortcut methods to configurations.
   module ConfigurationHelper
     delegate :controller_configuration, to: Wallaby
-    delegate :models, :security, :mapping, :pagination, :features, :sorting, to: :configuration
+    delegate :max_text_length, to: :controller_configuration
 
     # @return [Wallaby::Configuration] shortcut method of configuration
     def configuration
@@ -18,8 +18,28 @@ module Wallaby
       INSTRUCTION
     end
 
-    def max_text_length
-      controller_configuration.max_length
+    def mapping
+      Deprecator.alert method(__callee__), from: '0.3.0'
+    end
+
+    def security
+      Deprecator.alert method(__callee__), from: '0.3.0'
+    end
+
+    def models
+      Deprecator.alert method(__callee__), from: '0.3.0'
+    end
+
+    def pagination
+      Deprecator.alert method(__callee__), from: '0.3.0'
+    end
+
+    def features
+      Deprecator.alert method(__callee__), from: '0.3.0'
+    end
+
+    def sorting
+      Deprecator.alert method(__callee__), from: '0.3.0'
     end
   end
 end

--- a/lib/wallaby/configuration/features.rb
+++ b/lib/wallaby/configuration/features.rb
@@ -5,7 +5,9 @@ module Wallaby
     # Features global configuration
     class Features
       # @!attribute [w] turbolinks_enabled
-      attr_writer :turbolinks_enabled
+      def turbolinks_enabled=(_turbolinks_enabled)
+        Deprecator.alert 'config.features.turbolinks_enabled=', from: '0.3.0'
+      end
 
       # @!attribute [r] turbolinks_enabled
       # To globally configure whether to use turbolinks or not.
@@ -17,7 +19,11 @@ module Wallaby
       #   end
       # @return [Boolean] a feture flag of turbolinks, default to false.
       def turbolinks_enabled
-        @turbolinks_enabled ||= false
+        Deprecator.alert method(__callee__), from: '0.3.0', alternative: <<~INSTRUCTION
+          If Turbolinks is included, it will be used by Wallaby. If you want to disable it,
+          you can either take `turbolinks` gem out from your Gemfile
+          or override the `frontend` partial by taking it out.
+        INSTRUCTION
       end
     end
   end

--- a/lib/wallaby/configuration/metadata.rb
+++ b/lib/wallaby/configuration/metadata.rb
@@ -9,10 +9,10 @@ module Wallaby
       # @!attribute [w] max
       def max=(_max)
         Deprecator.alert 'config.metadata.max=', from: '0.3.0', alternative: <<~INSTRUCTION
-          Please set .max_length= from the controller instead, for example:
+          Please set .max_text_length= from the controller instead, for example:
 
             class Admin::ApplicationController < Wallaby::ResourcesController
-              self.max_length = 50
+              self.max_text_length = 50
             end
         INSTRUCTION
       end
@@ -21,7 +21,7 @@ module Wallaby
       # @!attribute [r] max
       def max
         Deprecator.alert 'config.metadata.max', from: '0.3.0', alternative: <<~INSTRUCTION
-          Please use controller_class.max_length instead.
+          Please use controller_class.max_text_length instead.
         INSTRUCTION
       end
     end

--- a/spec/deprecation/deprecations_spec.rb
+++ b/spec/deprecation/deprecations_spec.rb
@@ -143,3 +143,39 @@ describe Wallaby::Configuration::Sorting do
     it { expect { subject.strategy }.to raise_error Wallaby::MethodRemoved }
   end
 end
+
+describe Wallaby::Configuration::Features do
+  describe '#turbolinks_enabled=' do
+    it { expect { subject.turbolinks_enabled = nil }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#turbolinks_enabled' do
+    it { expect { subject.turbolinks_enabled }.to raise_error Wallaby::MethodRemoved }
+  end
+end
+
+describe Wallaby::ConfigurationHelper, type: :helper do
+  describe '#models' do
+    it { expect { helper.models }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#mapping' do
+    it { expect { helper.mapping }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#security' do
+    it { expect { helper.security }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#features' do
+    it { expect { helper.features }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#sorting' do
+    it { expect { helper.sorting }.to raise_error Wallaby::MethodRemoved }
+  end
+
+  describe '#pagination' do
+    it { expect { helper.pagination }.to raise_error Wallaby::MethodRemoved }
+  end
+end

--- a/spec/deprecation/deprecations_spec.rb
+++ b/spec/deprecation/deprecations_spec.rb
@@ -1,11 +1,5 @@
 require 'rails_helper'
 
-describe Wallaby::ConfigurationHelper, type: :helper do
-  describe '#default_metadata' do
-    it { expect { helper.default_metadata }.to raise_error Wallaby::MethodRemoved }
-  end
-end
-
 describe Wallaby::Map do
   describe '.model_classes' do
     it { expect { described_class.model_classes }.to raise_error Wallaby::MethodRemoved }
@@ -155,6 +149,10 @@ describe Wallaby::Configuration::Features do
 end
 
 describe Wallaby::ConfigurationHelper, type: :helper do
+  describe '#default_metadata' do
+    it { expect { helper.default_metadata }.to raise_error Wallaby::MethodRemoved }
+  end
+
   describe '#models' do
     it { expect { helper.models }.to raise_error Wallaby::MethodRemoved }
   end

--- a/spec/features/controller_configuration/other_related_spec.rb
+++ b/spec/features/controller_configuration/other_related_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe Wallaby::ResourcesController do
-  describe '.max_length' do
+  describe '.max_text_length' do
     it 'returns nil' do
-      expect(described_class.try(:max_length)).to eq Wallaby::DEFAULT_MAX
+      expect(described_class.try(:max_text_length)).to eq Wallaby::DEFAULT_MAX
     end
 
     context 'when subclasses' do
@@ -13,24 +13,24 @@ describe Wallaby::ResourcesController do
         end))
       end
 
-      it 'returns its max_length' do
-        expect(application_controller.try(:max_length)).to eq Wallaby::DEFAULT_MAX
+      it 'returns its max_text_length' do
+        expect(application_controller.try(:max_text_length)).to eq Wallaby::DEFAULT_MAX
       end
 
-      context 'when application controller has its own max_length' do
+      context 'when application controller has its own max_text_length' do
         let(:application_value) { 10 }
 
-        it 'returns its max_length' do
-          application_controller.try :max_length=, application_value
-          expect(application_controller.try(:max_length)).to eq application_value
+        it 'returns its max_text_length' do
+          application_controller.try :max_text_length=, application_value
+          expect(application_controller.try(:max_text_length)).to eq application_value
         end
       end
 
-      context 'when application controller set max_length to an invalid value' do
+      context 'when application controller set max_text_length to an invalid value' do
         let(:application_value) { 'invalid_value' }
 
         it 'raises error' do
-          expect { application_controller.try :max_length=, application_value }.to raise_error ArgumentError
+          expect { application_controller.try :max_text_length=, application_value }.to raise_error ArgumentError
         end
       end
     end

--- a/spec/helpers/wallaby/application_helper_spec.rb
+++ b/spec/helpers/wallaby/application_helper_spec.rb
@@ -69,31 +69,4 @@ describe Wallaby::ApplicationHelper do
       end
     end
   end
-
-  describe '#stylesheet_link_tag' do
-    it 'does not include data-turbolinks attribute' do
-      expect(stylesheet_link_tag('application')).not_to include 'data-turbolinks-track="true"'
-    end
-
-    it 'inclues data-turbolinks attribute when turbolinks is enabled' do
-      Wallaby.configuration.features.turbolinks_enabled = true
-      expect(stylesheet_link_tag('application')).to include 'data-turbolinks-track="true"'
-      expect(stylesheet_link_tag('application', 'data-turbolinks-track' => nil)).not_to include 'data-turbolinks-track'
-    end
-  end
-
-  describe '#javascript_include_tag' do
-    it 'does not include data-turbolinks attribute' do
-      expect(javascript_include_tag('application')).not_to include 'data-turbolinks-track="true"'
-      expect(javascript_include_tag('application')).not_to include 'data-turbolinks-eval="false"'
-    end
-
-    it 'inclues data-turbolinks attribute when turbolinks is enabled' do
-      Wallaby.configuration.features.turbolinks_enabled = true
-      expect(javascript_include_tag('application')).to include 'data-turbolinks-track="true"'
-      expect(javascript_include_tag('application')).to include 'data-turbolinks-eval="false"'
-      expect(javascript_include_tag('application', 'data-turbolinks-track' => nil)).not_to include 'data-turbolinks-track'
-      expect(javascript_include_tag('application', 'data-turbolinks-eval' => nil)).not_to include 'data-turbolinks-eval'
-    end
-  end
 end

--- a/spec/helpers/wallaby/configuration_helper_spec.rb
+++ b/spec/helpers/wallaby/configuration_helper_spec.rb
@@ -5,23 +5,11 @@ describe Wallaby::ConfigurationHelper do
     it { expect(helper.configuration).to be_a Wallaby::Configuration }
   end
 
-  describe '#models' do
-    it { expect(helper.models).to be_a Wallaby::Configuration::Models }
+  describe '#controller_configuration' do
+    it { expect(helper.controller_configuration).to eq Wallaby::ResourcesController }
   end
 
-  describe '#security' do
-    it { expect(helper.security).to be_a Wallaby::Configuration::Security }
-  end
-
-  describe '#mapping' do
-    it { expect(helper.mapping).to be_a Wallaby::Configuration::Mapping }
-  end
-
-  describe '#pagination' do
-    it { expect(helper.pagination).to be_a Wallaby::Configuration::Pagination }
-  end
-
-  describe '#features' do
-    it { expect(helper.features).to be_a Wallaby::Configuration::Features }
+  describe '#max_text_length' do
+    it { expect(helper.max_text_length).to eq Wallaby::DEFAULT_MAX }
   end
 end

--- a/spec/lib/wallaby/configuration/features_spec.rb
+++ b/spec/lib/wallaby/configuration/features_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-describe Wallaby::Configuration::Features do
-  it_behaves_like \
-    'has attribute with default value',
-    :turbolinks_enabled, false
-end


### PR DESCRIPTION
### Summary

as titled