### PR TITLE
fix: proper clone solution

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
+    branches: [main, develop]
 jobs:
   pr-build:
     runs-on: ${{ matrix.os }}

--- a/lib/utils/wallaby/utils.rb
+++ b/lib/utils/wallaby/utils.rb
@@ -1,22 +1,34 @@
 # frozen_string_literal: true
 
 module Wallaby
-  # Utils
-  module Utils
-    # @see http://stackoverflow.com/a/8710663/1326499
+  module Utils # :nodoc:
     # @param object [Object]
-    # @return [Object] a clone object
+    # @return [Object] a cloned object
     def self.clone(object)
-      object.deep_dup
+      # NOTE: Neither marshal/deep_dup/dup is able to make a correct deep copy,
+      # therefore, this is our solution:
+      case object
+      when Hash
+        # NOTE: `default` should be cloned as well
+        object.each_with_object(object.class.new(object.default)) { |(key, value), hash| hash[key] = clone(value) }
+      when Array
+        object.each_with_object(object.class.new) { |value, array| array << clone(value) }
+      when Class
+        # NOTE: `Class.dup` turns the origin Class object into an anonymous clone.
+        # therefore, the Class object itself should be returned instead
+        object
+      else
+        object.dup
+      end
     end
 
     # @param object [Object, nil]
     # @return [String] inspection string for the given object
     def self.inspect(object)
-      return 'nil' unless object
-      return object.name if object.is_a? Class
+      return 'nil' if object.nil?
+      return "#{object.class}##{object.try(:id)}" if object.is_a?(::ActiveRecord::Base)
 
-      "#{object.class}##{object.try(:id)}"
+      object.inspect
     end
   end
 end

--- a/spec/concerns/wallaby/configurable_spec.rb
+++ b/spec/concerns/wallaby/configurable_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Wallaby::ResourcesController, type: :controller do
   describe '.resource_decorator && .application_decorator' do
     it 'returns decorator class' do
-      expect(described_class.resource_decorator).to eq nil
+      expect(described_class.resource_decorator).to be_nil
       expect(described_class.application_decorator).to eq Wallaby::ResourceDecorator
     end
 

--- a/spec/core/wallaby/class_hash_spec.rb
+++ b/spec/core/wallaby/class_hash_spec.rb
@@ -11,13 +11,13 @@ describe Wallaby::ClassHash do
     it 'assigns and return' do
       subject[Class] = Module
       expect(subject[Class]).to eq Module
-      expect(subject['Class']).to eq nil
+      expect(subject['Class']).to be_nil
       expect(subject.internal).to eq ['Class', true] => ['Module', true]
       expect(subject).to eq Class => Module
 
       subject[Class] = 'Module'
       expect(subject[Class]).to eq 'Module'
-      expect(subject['Class']).to eq nil
+      expect(subject['Class']).to be_nil
       expect(subject).to eq Class => 'Module'
 
       subject['Class'] = 'Module'

--- a/spec/utils/wallaby/utils_spec.rb
+++ b/spec/utils/wallaby/utils_spec.rb
@@ -1,9 +1,45 @@
 require 'rails_helper'
 
 describe Wallaby::Utils do
+  describe '.clone' do
+    it 'clones object' do
+      object = 'Post'
+      expect(described_class.clone(object)).to eq object
+      expect(described_class.clone(object).object_id).not_to eq object.object_id
+
+      object = { a: 1 }
+      expect(described_class.clone(object)).to eq object
+      expect(described_class.clone(object)[:a]).to eq object[:a]
+      expect(described_class.clone(object).object_id).not_to eq object.object_id
+
+      object.default = 2
+      expect(described_class.clone(object)).to eq object
+      expect(described_class.clone(object)[:a]).to eq object[:a]
+      expect(described_class.clone(object).default).to eq object.default
+      expect(described_class.clone(object).object_id).not_to eq object.object_id
+
+      object = ['a']
+      expect(described_class.clone(object)).to eq object
+      expect(described_class.clone(object)[0]).to eq object[0]
+      expect(described_class.clone(object)[0].object_id).not_to eq object[0].object_id
+      expect(described_class.clone(object).object_id).not_to eq object.object_id
+
+      object = String
+      expect(described_class.clone(object)).to eq object
+      expect(described_class.clone(object).object_id).to eq object.object_id
+
+      object = AllPostgresType.create text: 'test'
+      expect(described_class.clone(object)).not_to eq object
+      expect(described_class.clone(object).object_id).not_to eq object.object_id
+      expect(described_class.clone(object).id).to be_nil
+      expect(described_class.clone(object).attributes.except('id')).to eq object.attributes.except('id')
+    end
+  end
+
   describe '.inspect' do
     it 'returns filter name' do
       expect(described_class.inspect(nil)).to eq 'nil'
+      expect(described_class.inspect(false)).to eq 'false'
       expect(described_class.inspect(Person.new(id: 1))).to eq 'Person#1'
     end
   end


### PR DESCRIPTION
### Summary

Base on the facts that:
- Marshal clone doesn't work with the Class object that has singleton methods introduced in Rails 7.0.1
- `deep_dup`/`dup` doesn't clone Class object properly as it converts it into anonymous class clone

Therefore, we need to this proper solution for clone

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
