### PR TITLE
Fix for Rails 7.1.2 moving app folders out of eager_load_paths

### DIFF
--- a/lib/wallaby/core/version.rb
+++ b/lib/wallaby/core/version.rb
@@ -2,6 +2,6 @@
 
 module Wallaby
   module Core
-    VERSION = '0.2.8' # :nodoc:
+    VERSION = '0.2.9' # :nodoc:
   end
 end

--- a/lib/wallaby/preloader.rb
+++ b/lib/wallaby/preloader.rb
@@ -39,7 +39,10 @@ module Wallaby
     # @!attribute [r] eager_load_paths
     # @return [Array<String, Pathname>]
     def eager_load_paths # :nodoc:
-      @eager_load_paths ||= Rails.configuration.eager_load_paths
+      @eager_load_paths ||=
+        Rails.configuration.paths['app'].expanded
+          .concat(Rails.configuration.eager_load_paths)
+          .uniq
     end
 
     # @!attribute [w] model_paths


### PR DESCRIPTION
### Summary

This is a fix for Rails 7.1.2 as it's moving the app folders out of `Rails.configuration.eager_load_paths`

Before 7.1.2:

```ruby
Loading development environment (Rails 7.1.1)
irb(main):001> Rails.configuration.eager_load_paths
=>
["/Users/tian/workspace/me/wallaby-rails-7-1-2/app/channels",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/controllers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/controllers/concerns",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/decorators",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/helpers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/jobs",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/mailers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/models",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/models/concerns",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/servicers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/lib"]
```

7.1.2:

```ruby
irb(main):001> Rails.configuration.eager_load_paths
=> ["/Users/tian/workspace/me/wallaby-rails-7-1-2/lib"]
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
