### PR TITLE
Fix eager_load_paths issue for Rails 7.1.2 and above

### DIFF
--- a/lib/wallaby/preloader.rb
+++ b/lib/wallaby/preloader.rb
@@ -30,7 +30,9 @@ module Wallaby
     # @!attribute [r] eager_load_paths
     # @return [Array<String, Pathname>]
     def eager_load_paths # :nodoc:
-      @eager_load_paths ||= Rails.configuration.eager_load_paths
+      @eager_load_paths ||=
+        Rails.configuration.paths['app'].expanded
+          .concat(Rails.configuration.eager_load_paths)
     end
 
     # @!attribute [w] model_paths


### PR DESCRIPTION
Summary
This is a fix for Rails 7.1.2 as it's moving the app folders out of Rails.configuration.eager_load_paths

Before 7.1.2:

Loading development environment (Rails 7.1.1)
irb(main):001> Rails.configuration.eager_load_paths
=>
["/Users/tian/workspace/me/wallaby-rails-7-1-2/app/channels",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/controllers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/controllers/concerns",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/decorators",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/helpers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/jobs",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/mailers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/models",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/models/concerns",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/app/servicers",
 "/Users/tian/workspace/me/wallaby-rails-7-1-2/lib"]
7.1.2:

irb(main):001> Rails.configuration.eager_load_paths
=> ["/Users/tian/workspace/me/wallaby-rails-7-1-2/lib"]
Other Information