### PR TITLE
fix: object is not decorated by Rails' convert_to_model change

### DIFF
--- a/lib/decorators/wallaby/resource_decorator.rb
+++ b/lib/decorators/wallaby/resource_decorator.rb
@@ -179,6 +179,12 @@ module Wallaby
       resource.try(:model_name) || ActiveModel::Name.new(model_class)
     end
 
+    # @see https://github.com/rails/rails/compare/v7.0.2.4..7-0-stable#diff-44b94eca66c7497711821a8e6bcdfde4684bb7b8efa15e64da6532449f03ef0bR441
+    # @note This overwritten method is a response to the above change
+    def to_model
+      self
+    end
+
     # @note this method is for the Rails form helper methods to recognize non-ActiveModel models
     # @return [nil] if no primary key
     # @return [Array<String>] primary key


### PR DESCRIPTION
### Summary

Recent Rails' convert_to_model change causes form object being converted to active record instance, however, Wallaby expects a decorated object (which is the Wallaby::ResourceDecorator instance). This change is to fix this issue

https://github.com/rails/rails/compare/v7.0.2.4..7-0-stable#diff-44b94eca66c7497711821a8e6bcdfde4684bb7b8efa15e64da6532449f03ef0bR441

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Thanks for contributing! -->
